### PR TITLE
Update failing when updated column used in query 

### DIFF
--- a/database.php
+++ b/database.php
@@ -153,7 +153,7 @@ class Database extends PDO
 
         $fieldDetails = null;
         foreach ($data as $key => $value) {
-            $fieldDetails .= "$key = :$key,";
+            $fieldDetails .= "$key = :d_$key,";
         }
         $fieldDetails = rtrim($fieldDetails, ',');
 
@@ -161,9 +161,9 @@ class Database extends PDO
         $i = 0;
         foreach ($where as $key => $value) {
             if ($i == 0) {
-                $whereDetails .= "$key = :$key";
+                $whereDetails .= "$key = :w_$key";
             } else {
-                $whereDetails .= " AND $key = :$key";
+                $whereDetails .= " AND $key = :w_$key";
             }
             $i++;
         }
@@ -172,11 +172,11 @@ class Database extends PDO
         $stmt = $this->prepare("UPDATE $table SET $fieldDetails WHERE $whereDetails");
 
         foreach ($data as $key => $value) {
-            $stmt->bindValue(":$key", $value);
+            $stmt->bindValue(":d_$key", $value);
         }
 
         foreach ($where as $key => $value) {
-            $stmt->bindValue(":$key", $value);
+            $stmt->bindValue(":w_$key", $value);
         }
 
         $stmt->execute();


### PR DESCRIPTION
When an update is performed on a field that is also in the query then the update statement fails.

For example:
```
$data = array(
		'email_address'  => 'new.email@domain.com'
              );
$where = array(
		'email_address'  => 'old.email@domain.com'
              );
$db->update('users', $data, $where);
```

will produce the following SQL statement:
```
UPDATE users SET email_address = :email_address WHERE email_address = :email_address
```

... however the bindValue will only contain:
```
{
	":email_address"  => 'old.email@domain.com'
}
```
so the evaluated SQL command is invalid:
```
UPDATE users SET email_address = 'old.email@domain.com' WHERE email_address =  'old.email@domain.com'
```