### PR TITLE
Improved update Method with Flexible WHERE Conditions

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -194,13 +194,14 @@ class Database
      * 
      * @param  string $table table name
      * @param  array $data  array of columns and values
-     * @param  array $where array of columns and values
+     * @param  object $where array of columns and values or string of query
+     * @param  array $args params of query
      */
-    public function update($table, $data, $where)
+    public function update($table, $data, $where, $args = [])
     {
         //collect the values from data and where
         $values = [];
-        
+
         //setup fields
         $fieldDetails = null;
         foreach ($data as $key => $value) {
@@ -212,16 +213,30 @@ class Database
         
         //setup where 
         $whereDetails = null;
-        $i = 0;
-        foreach ($where as $key => $value) {
-            $key = '`' . trim($key, '`') . '`';
-            $whereDetails .= $i == 0 ? "$key = ?" : " AND $key = ?";
-            $values[] = $value;
-            $i++;
+        if (is_string($where)) {
+            $where = trim($where);
+            $whereDetails = $where ?: '';
+            $values = array_merge($values, $args);
         }
-        
-        $stmt = $this->run("UPDATE $table SET $fieldDetails WHERE $whereDetails", $values);
-        
+        else {
+            $i = 0;
+            foreach ($where as $key => $value) {
+                $key = '`' . trim($key, '`') . '`';
+                $whereDetails .= $i == 0 ? "$key = ?" : " AND $key = ?";
+                $values[] = $value;
+                $i++;
+            }
+        }
+
+        // build SQL statement
+        $sql = "UPDATE $table SET $fieldDetails";
+        if ($whereDetails) {
+            $sql .= " WHERE $whereDetails";
+        }
+
+        //execute query
+        $stmt = $this->run($sql, $values);
+
         return $stmt->rowCount();
     }
 


### PR DESCRIPTION
The original update method only supported an array-based WHERE condition, which limited flexibility when handling more complex conditions (e.g., using OR, nested conditions, or raw SQL expressions). To address this limitation, I have modified the method to support custom WHERE clauses.

I have implemented two versions of the updated method, allowing you to choose the one that best fit for this project.

1. Modify the original function

```
update('users', ['name' => 'John'], 'id = ? OR email = ?', [10, 'test@example.com']);
```

2. Add a new function
```
updateByWhere('users', ['name' => 'John'], 'id = ? OR email = ?', [10, 'test@example.com']);
```